### PR TITLE
Populate a default usage for commands with flags.

### DIFF
--- a/help.go
+++ b/help.go
@@ -82,7 +82,7 @@ func (c *C) HelpInfo(flags HelpFlags) HelpInfo {
 		Synopsis: strings.SplitN(help, "\n", 2)[0],
 		Help:     help,
 	}
-	if u := c.usageLines(); len(u) != 0 {
+	if u := c.usageLines(flags); len(u) != 0 {
 		h.Usage = "Usage:\n\n" + indent(prefix, prefix, strings.Join(u, "\n"))
 	}
 	if c.hasFlagsDefined(flags.wantPrivateFlags()) {

--- a/utils.go
+++ b/utils.go
@@ -20,7 +20,7 @@ func Flags(bind func(*flag.FlagSet, any), vs ...any) func(*Env, *flag.FlagSet) {
 
 // usageLines parses and normalizes usage lines. The command name is stripped
 // from the head of each line if it is present.
-func (c *C) usageLines() []string {
+func (c *C) usageLines(flags HelpFlags) []string {
 	var lines []string
 	prefix := c.Name + " "
 	for _, line := range strings.Split(c.Usage, "\n") {
@@ -32,6 +32,9 @@ func (c *C) usageLines() []string {
 		} else {
 			lines = append(lines, strings.TrimPrefix(line, prefix))
 		}
+	}
+	if len(lines) == 0 && c.hasFlagsDefined(flags.wantPrivateFlags()) {
+		return []string{"[flags]"}
 	}
 	return lines
 }


### PR DESCRIPTION
If the Usage field is empty but the command defines (non-hidden) flags, present
a usage indicating the command accepts flags, e.g.,

   Usage:
      cmdname [flags]

Explicitly-set usage overrides this, and commands with neither flags nor
explicit usage continue to omit the usage section entirely.
