### PR TITLE
Fix Run with multiple levels of subcommands.

### DIFF
--- a/command.go
+++ b/command.go
@@ -266,7 +266,7 @@ func (c *C) Runnable() bool { return c != nil && (c.Run != nil || c.Init != nil)
 func (c *C) HasRunnableSubcommands() bool {
 	if c != nil {
 		for _, cmd := range c.Commands {
-			if cmd.Runnable() {
+			if cmd.Runnable() || cmd.HasRunnableSubcommands() {
 				return true
 			}
 		}


### PR DESCRIPTION
Without this, commands can only have one level of children. A command like 'cmd foo bar', where 'foo' has no Run of its own, returns a mysterious 'command "foo" not understood'.